### PR TITLE
Exploit CVE-2020-9547 with vulnerable version of jackson-databind

### DIFF
--- a/slim-demo/pom.xml
+++ b/slim-demo/pom.xml
@@ -40,7 +40,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>${library-version}</version>
+			<version>2.9.10.3</version>
 		</dependency>
 
 		<!-- Gadgets related to CVE-2020-9547 -->


### PR DESCRIPTION
This PR shows a basic exploit of CVE-2020-9547 to execute code on the host.